### PR TITLE
adds nginx container config and doc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM nginx:latest
+
+# Path: /etc/nginx/nginx.conf
+COPY etc/nginx/default.conf /etc/nginx/conf.d/default.conf

--- a/README.MD
+++ b/README.MD
@@ -1,7 +1,13 @@
-# cncf.io subdomain redirector
+# Subdomain Redirector for cncf.io
 
-An nginx container that will redirect requests to subdomains of cncf.io to appropriate locations as requested by the CNCF community.
+A small nginx config/instance to handle graceful redirects from *.cncf.io subdomain names for various purposes.
 
-Initially created to satisfy this request
+This was requested by the community for various CNCF-wide libraries.
 
-<https://github.com/cncf/toc/issues/1152>
+[Request for vanity URL to be used as the module prefix of go repos in the cncf-tags GitHub organization #1152][cncf/toc issue #1152]
+
+## Origins
+
+A pattern was created by Kubernetes to serve go packages from `sigs.k8s.io`.
+
+[cncf/toc issue #1152]: https://github.com/cncf/toc/issues/1152

--- a/etc/nginx/default.conf
+++ b/etc/nginx/default.conf
@@ -1,0 +1,41 @@
+# https://github.com/cncf/toc/issues/1152
+server {
+  server_name tags.cncf.io;
+  listen 80 default_server;
+
+  location = /_healthz {
+    add_header Content-Type text/plain;
+    return 200 'ok';
+  }
+
+  location ~ ^/(?<repo>[^/]*)(?<subpath>/.*)?$ {
+    # $https is set to 'on' when connecting to nginx via HTTPS directly.
+    set $https_status $https;
+    if ($http_x_forwarded_proto = 'https') {
+      set $https_status 'on';
+    }
+    # Upgrade HTTP to HTTPS.
+    if ($https_status != 'on') {
+      return 301 https://$host$request_uri;
+    }
+
+    if ($arg_go-get = "1") {
+      # This is a go-get operation.
+      return 200 '
+          <html><head>
+                <meta name="go-import"
+                      content="tags.cncf.io/$repo
+                                git https://github.com/cncf-tags/$repo">
+                <meta name="go-source"
+                      content="tags.cncf.io/$repo
+                                https://github.com/cncf-tags/$repo
+                                https://github.com/cncf-tags/$repo/tree/master{/dir}
+                                https://github.com/cncf-tags/$repo/blob/master{/dir}/{file}#L{line}">
+          </head></html>
+      ';
+    }
+
+    # Default to redirecting to the "real" site.
+    return 301 https://cncf-tags.io$request_uri;
+  }
+}


### PR DESCRIPTION
Builds out a basic container that runs an nginx reverse proxy  

from pair session with @jeefy in preparation for initial deployment and testing. 

For  cncf/toc#1152

